### PR TITLE
ci: upgrade shared pnpm-verify.yml - add command input, fix codecov, improve snapshots

### DIFF
--- a/.github/workflows/pnpm-verify.yml
+++ b/.github/workflows/pnpm-verify.yml
@@ -13,6 +13,10 @@ on:
       pnpm-version:
         type: string
         required: false
+      command:
+        type: string
+        required: false
+        default: 'verify'
       codecov-flags:
         type: string
         required: false
@@ -40,19 +44,22 @@ jobs:
 
       - name: Verify
         if: matrix.os == 'ubuntu-latest'
-        run: xvfb-run -a pnpm verify
+        run: xvfb-run -a pnpm ${{ inputs.command }}
       - name: Verify
         if: matrix.os != 'ubuntu-latest'
-        run: pnpm verify
+        run: pnpm ${{ inputs.command }}
 
-      - name: Archive snapshots/linux
+      - name: Archive snapshots
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: snapshots
-          path: '**/__snapshots__/linux'
+          path: |
+            **/__snapshots__/linux
+            **/__vis__/**/__diffs__
+            **/__vis__/**/__results__
       - name: codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 'lts/*'
         uses: codecov/codecov-action@v6
         with:
           flags: ${{ inputs.codecov-flags }}


### PR DESCRIPTION
## Summary
- Add `command` input (default: `verify`) to support repos using `verify:ci`
- Fix codecov condition from hardcoded `node-version == 20` to `lts/*`
- Combine snapshot archive paths to cover both `__snapshots__/linux` and `__vis__` patterns