### PR TITLE
fix(release): put the v1 line back on changesets/action@v1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,14 @@
 {
   "extends": [
     "github>unional/renovate-preset"
+  ],
+  "packageRules": [
+    {
+      "description": "changesets/action's major is the v1/v2 line boundary, not a dependency bump. Moving it is a deliberate release decision made alongside the consumers' @changesets/cli major. See README 'Why there are two lines'.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["changesets/action"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
   ]
 }

--- a/.github/workflows/pnpm-release-changeset-oidc.yml
+++ b/.github/workflows/pnpm-release-changeset-oidc.yml
@@ -81,7 +81,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - name: Install vsce
         run: pnpm install -g vsce
@@ -91,7 +91,7 @@ jobs:
       # No .npmrc token step: the OIDC exchange supplies credentials at publish time.
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.1.1
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: pnpm run version

--- a/.github/workflows/pnpm-release-changeset.yml
+++ b/.github/workflows/pnpm-release-changeset.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - name: Install vsce
         run: pnpm install -g vsce
@@ -53,7 +53,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.1.1
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: pnpm run version

--- a/.github/workflows/pnpm-verify.yml
+++ b/.github/workflows/pnpm-verify.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright browsers
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 
       - name: Verify
         if: matrix.os == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ lines exist in parallel rather than one being a migration deadline:
 | --- | --- | --- |
 | `repobuddy/repobuddy` | `^3.0.0` | `@v2` |
 | `repobuddy/storybook` | `^2.29.7` | `@v1` |
-| `repobuddy/visual-testing` | `^2.29.8` | `@v1` |
+| `repobuddy/visual-testing` | `^3.0.0` | `@v2` |
 | `repobuddy/rolldown-inline-type-exports` | `^2.29.8` | `@v1` |
 | `repobuddy/jest-watch-toggle-config-2` | `^2.25.2` | `@v1` |
 
@@ -125,6 +125,13 @@ the next release was attempted.
 Tagging fixes the consumer half of this — an auto-merged bump now lands on
 `main` and waits there until someone cuts a release. The Mergify rule not
 actually excluding majors is a separate defect and should be fixed on its own.
+
+It kept happening after the lines were split: Renovate carried `main` on to
+`changesets/action` `v2`, `v2.1.0` and `v2.1.1` while `main` is the v1 line, so
+the v1 workflows ran action v2 against v1 input names and every release on that
+line aborted with *"The following inputs have been renamed"*. `.github/renovate.json`
+now disables major updates for `changesets/action` outright, because that major
+is the line boundary — it is moved by cutting a new line, never by a bump.
 
 ### Starting version: `v1.0.0`
 
@@ -287,22 +294,16 @@ and `v2` substituted.
 Step 3 is the one that is easy to get wrong or forget. If the alias is not
 moved, the release is invisible to everyone pinning it.
 
-#### Known gap: internal refs still float on `@main`
+#### Internal refs
 
 Workflows in this repo consume this repo's own composite action:
 
 ```text
-        uses: repobuddy/.github/.github/actions/setup-playwright@main
+        uses: repobuddy/.github/.github/actions/setup-playwright@v1
 ```
 
 A reusable workflow cannot reference a sibling action by relative path — `./`
 resolves against the *caller's* checkout, not this repo's — so these must be
-fully-qualified `owner/repo/path@ref`, and today that ref is `@main`. **A
-consumer pinned at `@v1` therefore still picks up `setup-playwright` from
-`main`,** which partially defeats the pin.
-
-This is deliberately not fixed in the same change that introduces the scheme:
-re-pointing them to `@v1` before `v1` exists would break every current consumer
-immediately. Once `v1.0.0` is cut, change these to `@v1` on `main` and `@v2` on
-`v2.x` — the moving aliases, so they do not need touching on every subsequent
-release — and include that edit in the following release.
+fully-qualified `owner/repo/path@ref`. They carry the moving alias of their own
+line: `@v1` on `main`, `@v2` on `v2.x`. That way a consumer pinned at `@v1` gets
+`setup-playwright` from `v1` too, and the refs need no touching on each release.


### PR DESCRIPTION
Closes the break behind [#43](https://github.com/repobuddy/.github/issues/43)-style failures now showing up in `repobuddy/visual-testing`.

## What broke

`main` is the v1 line: `pnpm-release-changeset.yml` and `pnpm-release-changeset-oidc.yml` pair `changesets/action@v1` with consumers on `@changesets/cli` v2. Renovate auto-merged three bumps onto it anyway — `v2`, `v2.1.0`, `v2.1.1` — leaving action v2 running against v1 input names. Every release on the line aborts:

```
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit" -> "commit-mesage"
```

The oidc variant still carries a header comment saying it pairs action v1 with CLI v2, which is how obvious the regression is.

## What this does

- Both release workflows go back to `changesets/action@v1`.
- `.github/renovate.json` disables **major** updates for `changesets/action`. That major is the v1/v2 line boundary — it moves by cutting a new line alongside consumers' CLI major, never by a dependency bump. The Mergify `head~=^(?!major-)` guard does not match Renovate branch names and so never held it back; that defect is still open separately, this just takes the one dependency that cannot survive it out of Renovate's hands.
- README: `repobuddy/visual-testing` moves to `@changesets/cli` `^3.0.0` / `@v2` (see repobuddy/visual-testing#844).
- Closes the README's own "Known gap": the workflows' `setup-playwright` refs move from `@main` to `@v1`, so a consumer pinned at `@v1` no longer picks the composite action off `main`. The README said to do this once `v1.0.0` was cut, and it has been.

## After merging

Re-point the moving alias, or none of this reaches consumers:

```bash
git checkout main && git pull
git tag -a v1.0.1 -m "v1.0.1" && git push origin v1.0.1
gh release create v1.0.1 --generate-notes
git tag -f v1 v1.0.1 && git push -f origin v1
```

## Not in this PR

`v2.x` is on `changesets/action@v2.0.0` and its internal `setup-playwright` refs still say `@main`. Both want the same treatment on that branch (`@v2.1.1` and `@v2`) plus a `v2.0.1` release. Nothing is broken there today, so it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
